### PR TITLE
Make desiutil optional in setup.py

### DIFF
--- a/doc/changes.rst
+++ b/doc/changes.rst
@@ -5,7 +5,14 @@ prospect's Change Log
 1.0.1 (unreleased)
 ------------------
 
-* No changes yet.
+* Make desiutil_ imports optional in ``setup.py`` (PR `#56`_).
+* Adapt scripts to blanc ("deep" directories) (8552fd8e_).
+* Support ``SV1_BGS_TARGET`` (7a5ca41f_).
+
+.. _desiutil: https://github.com/desihub/desiutil
+.. _`#56`: https://github.com/desihub/prospect/pull/56
+.. _8552fd8e: https://github.com/desihub/prospect/commit/8552fd8ec1801d322e9df3b468ed319109410763
+.. _7a5ca41f: https://github.com/desihub/prospect/commit/7a5ca41f41d1e7475c579b256b1e9fdccafe530f
 
 1.0.0 (2020-12-22)
 ------------------
@@ -21,10 +28,11 @@ be expected.  See PR `#54`_ for details.
 
 * Planned final reference tag before package refactor.
 * Allow prospect to be loaded in an environment without the DESI software stack (PR `#50`_).
-* Allow specutils objects to be plotted (PR `#43`_).
+* Allow specutils_ objects to be plotted (PR `#43`_).
 
 .. _`#50`: https://github.com/desihub/prospect/pull/50
 .. _`#43`: https://github.com/desihub/prospect/pull/43
+.. _specutils: https://specutils.readthedocs.io
 
 0.2.2 (2020-07-04)
 ------------------

--- a/py/prospect/test/t/test_read_vi.csv
+++ b/py/prospect/test/t/test_read_vi.csv
@@ -1,0 +1,3 @@
+TARGETID,EXPID,NIGHT,TILEID,Spec_version,Redrock_version,Template_version,Redrock_spectype,Redrock_z,VI_scanner,VI_quality,VI_issue,VI_z,VI_spectype,VI_comment
+123456789,12345,20200703,65432,0.33.3,0.22.2,1.0,GALAXY,0.22,Desi Arnaz,1,R,0.23,QSO,"This is a comment containing a , comma."
+987654321,12345,20200703,65432,0.33.3,0.22.2,1.0,STAR,0.0003,Desi Arnaz,4,C,0.0004,STAR,"This looks nice"

--- a/py/prospect/test/test_utilities.py
+++ b/py/prospect/test/test_utilities.py
@@ -5,7 +5,8 @@
 import unittest
 import re
 import sys
-from ..utilities import get_resources
+from pkg_resources import resource_filename
+from ..utilities import vi_file_fields, get_resources, read_vi
 
 
 class TestUtilities(unittest.TestCase):
@@ -14,7 +15,8 @@ class TestUtilities(unittest.TestCase):
 
     @classmethod
     def setUpClass(cls):
-        pass
+        cls.vi_colnames = [v[0] for v in vi_file_fields]
+        cls.vi_dtype = [v[2] for v in vi_file_fields]
 
     @classmethod
     def tearDownClass(cls):
@@ -33,6 +35,16 @@ class TestUtilities(unittest.TestCase):
         bar = get_resources('js')
         with self.assertRaises(ValueError):
             bad = get_resources('foo')
+
+    # def test_read_vi(self):
+    #     """Test reading of VI files.
+    #     """
+    #     with self.assertRaises(ValueError) as e:
+    #         vi = read_vi('foo.txt')
+    #     self.assertEqual(str(e.exception), 'Invalid file extension: .txt!')
+    #     csv = resource_filename('prospect.test', 't/test_read_vi.csv')
+    #     vi = read_vi(csv)
+    #     self.assertListEqual(vi.colnames, self.vi_colnames)
 
 
 def test_suite():

--- a/py/prospect/utilities.py
+++ b/py/prospect/utilities.py
@@ -68,7 +68,7 @@ vi_file_fields = [
     #      associated variable in cds_targetinfo,
     #      dtype in VI file ]
     # Ordered list
-    ["TARGETID", "targetid", "i4"],
+    ["TARGETID", "targetid", "i8"],
     ["EXPID", "expid", "i4"],
     ["NIGHT", "night", "i4"],
     ["TILEID", "tileid", "i4"],
@@ -146,21 +146,25 @@ def read_vi(vifile):
     -------
     :class`~astropy.table.Table`
         The full VI catalog.
+
+    Raises
+    ------
+    ValueError
+        If the extension is invalid, or if the file contains invalid columns.
     '''
     vi_records = [x[0] for x in vi_file_fields]
     vi_dtypes = [x[2] for x in vi_file_fields]
-
-    if (vifile[-5:] != ".fits" and vifile[-4:] not in [".fit",".fts",".csv"]) :
-        raise RuntimeError("wrong file extension")
-    if vifile[-4:] == ".csv" :
-        vi_info = Table.read(vifile,format='ascii.csv', names=vi_records)
-        for i,rec in enumerate(vi_records) :
+    _, ext = os.path.splitext(vifile)
+    if ext not in ('.fits', '.fit', '.fts', '.csv'):
+        raise ValueError(f"Invalid file extension: {ext}!")
+    if ext == ".csv":
+        vi_info = Table.read(vifile, format='ascii.csv', names=vi_records)
+        for i, rec in enumerate(vi_records):
             vi_info[rec] = vi_info[rec].astype(vi_dtypes[i])
-    else :
-        vi_info = astropy.io.fits.getdata(vifile,1)
-        if [(x in vi_info.names) for x in vi_records]!=[1 for x in vi_records] :
-            raise RuntimeError("wrong record names in VI fits file")
-        vi_info = Table(vi_info)
+    else:
+        vi_info = Table.read(vifile)
+        if [(x in vi_info.names) for x in vi_records] != [True for x in vi_records]:
+            raise ValueError("Wrong record names in VI fits file!")
 
     return vi_info
 

--- a/setup.py
+++ b/setup.py
@@ -14,7 +14,11 @@ from setuptools import setup, find_packages
 #
 # DESI support code.
 #
-import desiutil.setup as ds
+have_desiutil = True
+try:
+    import desiutil.setup as ds
+except ImportError:
+    have_desiutil = False
 #
 # Begin setup
 #
@@ -31,7 +35,14 @@ setup_keywords['url'] = 'https://github.com/desihub/prospect'
 #
 # END OF SETTINGS THAT NEED TO BE CHANGED.
 #
-setup_keywords['version'] = ds.get_version(setup_keywords['name'])
+if have_desiutil:
+    setup_keywords['version'] = ds.get_version(setup_keywords['name'])
+else:
+    try:
+        with open(os.path.join('py', setup_keywords['name'], '_version.py')) as v:
+            setup_keywords['version'] = v.read().split('=')[1].strip().strip("'").strip('"')
+    except FileNotFoundError:
+        setup_keywords['version'] = '0.0.1'
 #
 # Use README.rst as long_description.
 #
@@ -54,11 +65,12 @@ setup_keywords['zip_safe'] = False
 setup_keywords['use_2to3'] = False
 setup_keywords['packages'] = find_packages('py')
 setup_keywords['package_dir'] = {'': 'py'}
-setup_keywords['cmdclass'] = {'module_file': ds.DesiModule,
-                              'version': ds.DesiVersion,
-                              'test': ds.DesiTest,
-                              'api': ds.DesiAPI,
-                              'sdist': DistutilsSdist}
+setup_keywords['cmdclass'] = {'sdist': DistutilsSdist}
+if have_desiutil:
+    setup_keywords['cmdclass']['module_file'] = ds.DesiModule
+    setup_keywords['cmdclass']['version'] = ds.DesiVersion
+    setup_keywords['cmdclass']['test'] = ds.DesiTest
+    setup_keywords['cmdclass']['api'] = ds.DesiAPI
 setup_keywords['test_suite']='{name}.test.{name}_test_suite'.format(**setup_keywords)
 #
 # Autogenerate command-line scripts.

--- a/setup.py
+++ b/setup.py
@@ -85,8 +85,8 @@ setup_keywords['test_suite']='{name}.test.{name}_test_suite'.format(**setup_keyw
 #
 # Add internal data directories.
 #
-setup_keywords['package_data'] = {'prospect': ['data/*', 'js/*', 'templates/*'],}
-#                                   'prospect.test': ['t/*']}
+setup_keywords['package_data'] = {'prospect': ['data/*', 'js/*', 'templates/*'],
+                                  'prospect.test': ['t/*']}
 #
 # Run setup command.
 #


### PR DESCRIPTION
This PR supplements #54 by making `desiutil` not required for the operations of the top-level setup.py file.

@armengau, I also want to update the change log based on changes recently made directly to the master branch.  Could you please provide some text for that?