### PR TITLE
Workaround for masked SUBTYPE when selecting templates

### DIFF
--- a/doc/changes.rst
+++ b/doc/changes.rst
@@ -5,8 +5,10 @@ prospect's Change Log
 1.2.4 (unreleased)
 ------------------
 
+* Workaround masked ``SUBTYPE`` when loading templates (PR `#81`_).
 * Update API documentation and test infrastructure (PR `#79`_).
 
+.. _`#81`: https://github.com/desihub/prospect/pull/81
 .. _`#79`: https://github.com/desihub/prospect/pull/79
 
 1.2.3 (2022-09-15)

--- a/py/prospect/viewer/__init__.py
+++ b/py/prospect/viewer/__init__.py
@@ -20,6 +20,7 @@ import os, sys
 from pkg_resources import resource_filename
 
 import numpy as np
+from numpy.ma.core import MaskedConstant
 import scipy.ndimage.filters
 
 from astropy.table import Table
@@ -101,7 +102,11 @@ def create_model(spectra, zcat, archetype_fit=False, archetypes_dir=None, templa
                 model_flux[band][i] = spectra.R[band][i].dot(mx)
 
         else:
-            tx    = templates[(zb['SPECTYPE'], zb['SUBTYPE'])]
+            if isinstance(zb['SUBTYPE'], MaskedConstant):
+                subtype = zcat['SUBTYPE'].data.data[i].decode('utf-8')
+            else:
+                subtype = zb['SUBTYPE']
+            tx    = templates[(zb['SPECTYPE'], subtype)]
             coeff = zb['COEFF'][0:tx.nbasis]
             model = tx.flux.T.dot(coeff).T
 


### PR DESCRIPTION
This PR closes #80.  It also updates the `Prospect_demo.ipynb` notebook to use `fuji` and kernel `DESI 22.5`. We may want to further update the notebook to use `DESI main` after merging, since it could be some time before a tag with this fix is added to a full DESI release.