### PR TITLE
Don't use mask information to mark bad pixels in SDSS.

### DIFF
--- a/doc/changes.rst
+++ b/doc/changes.rst
@@ -5,20 +5,22 @@ prospect's Change Log
 1.3.1 (unreleased)
 ------------------
 
-* No changes yet.
+* Don't use mask information when marking bad pixels in SDSS data (PR `#94`_).
+
+.. _`#94`: https://github.com/desihub/prospect/pull/94
 
 1.3.0 (2023-09-06)
 ------------------
 
-* Added/renamed options to be run with `prospect_pages`:
-  --no_imaging
-  --no_noise
-  --no_thumb_tab
-  --no_vi_widgets
-  --no_coaddcam (PR `#90`_).
-* Renamed options in prospect_pages: 
-  --nspecperfile is renamed --nspec_per_page
-  --no-clean_fiberstatus is renamed --no_clean_fiberstatus
+* Added/renamed options to be run with :command:`prospect_pages` (PR `#90`_):
+  - ``--no_imaging``
+  - ``--no_noise``
+  - ``--no_thumb_tab``
+  - ``--no_vi_widgets``
+  - ``--no_coaddcam``
+* Renamed options in prospect_pages:
+  - ``--nspecperfile`` is renamed ``--nspec_per_page``
+  - ``--no-clean_fiberstatus`` is renamed ``--no_clean_fiberstatus``
 
 .. _`#90`: https://github.com/desihub/prospect/pull/90
 

--- a/py/prospect/viewer/__init__.py
+++ b/py/prospect/viewer/__init__.py
@@ -227,6 +227,8 @@ def plotspectra(spectra, zcatalog=None, redrock_cat=None, notebook=False, html_d
         survey = 'DESI'
         nspec = spectra[0].flux.shape[0]
         for s in spectra:
+            # For DESI, anything that has a non-zero mask should also already
+            # have ivar == 0, so this may be redundant, but should also be harmless.
             bad = (s.uncertainty.array == 0.0) | s.mask
             s.flux[bad] = np.nan
     else:
@@ -247,6 +249,8 @@ def plotspectra(spectra, zcatalog=None, redrock_cat=None, notebook=False, html_d
                     "    _specutils_imported = "+str(_specutils_imported)+"\n"+
                     "    _desispec_imported = "+str(_desispec_imported))
         for band in spectra.bands:
+            # For DESI, anything that has a non-zero mask should also already
+            # have ivar == 0, so this may be redundant, but should also be harmless.
             bad = (spectra.ivar[band] == 0.0) | (spectra.mask[band] != 0)
             spectra.flux[band][bad] = np.nan
         #- No coaddition if spectra is already single-band

--- a/py/prospect/viewer/__init__.py
+++ b/py/prospect/viewer/__init__.py
@@ -93,7 +93,7 @@ def create_model(spectra, zcat, archetype_fit=False, archetypes_dir=None, templa
         if archetype_fit:
             archetype  = archetypes[zb['SPECTYPE']]
             coeff      = zb['COEFF']
-            
+
             for band in spectra.bands:
                 wave                = spectra.wave[band]
                 wavehash            = hash((len(wave), wave[0], wave[1], wave[-2], wave[-1], spectra.R[band].data.shape[0]))
@@ -219,10 +219,11 @@ def plotspectra(spectra, zcatalog=None, redrock_cat=None, notebook=False, html_d
         # We will assume this is from an SDSS/BOSS/eBOSS spPlate file.
         survey = 'SDSS'
         nspec = spectra.flux.shape[0]
-        bad = (spectra.uncertainty.array == 0.0) | spectra.mask
+        # Historically, SDSS ignored any mask when marking bad pixels in plots.
+        bad = (spectra.uncertainty.array == 0.0)
         spectra.flux[bad] = np.nan
     elif _specutils_imported and isinstance(spectra, SpectrumList):
-        # We will assume this is from a DESI spectra-64 file.
+        # We will assume this is from a DESI spectra or coadd file.
         survey = 'DESI'
         nspec = spectra[0].flux.shape[0]
         for s in spectra:
@@ -243,14 +244,14 @@ def plotspectra(spectra, zcatalog=None, redrock_cat=None, notebook=False, html_d
                 )
         else:
             raise ValueError("Unsupported type for input spectra. \n"+
-                    "    _specutils_imported = "+str(_specutils_imported)+"\n"+ 
+                    "    _specutils_imported = "+str(_specutils_imported)+"\n"+
                     "    _desispec_imported = "+str(_desispec_imported))
         for band in spectra.bands:
             bad = (spectra.ivar[band] == 0.0) | (spectra.mask[band] != 0)
             spectra.flux[band][bad] = np.nan
         #- No coaddition if spectra is already single-band
         if len(spectra.bands)==1 : with_coaddcam = False
-    
+
     if title is None:
         title = "prospect"
 
@@ -313,7 +314,7 @@ def plotspectra(spectra, zcatalog=None, redrock_cat=None, notebook=False, html_d
             viewer_cds.init_model(model_2ndfit, second_fit=True)
 
     viewer_cds.load_metadata(spectra, mask_type=mask_type, zcatalog=zcatalog, survey=survey)
-    
+
     #-------------------------
     #-- Graphical objects --
     #-------------------------
@@ -321,7 +322,7 @@ def plotspectra(spectra, zcatalog=None, redrock_cat=None, notebook=False, html_d
     viewer_plots = ViewerPlots()
     viewer_plots.create_mainfig(spectra, title, viewer_cds, survey,
                                 with_noise=with_noise, with_coaddcam=with_coaddcam)
-    viewer_plots.create_zoomfig(viewer_cds, 
+    viewer_plots.create_zoomfig(viewer_cds,
                                 with_noise=with_noise, with_coaddcam=with_coaddcam)
     if with_imaging :
         viewer_plots.create_imfig(spectra)
@@ -332,7 +333,7 @@ def plotspectra(spectra, zcatalog=None, redrock_cat=None, notebook=False, html_d
     viewer_cds.load_spectral_lines(z)
     viewer_plots.add_spectral_lines(viewer_cds, figure='main')
     viewer_plots.add_spectral_lines(viewer_cds, figure='zoom', label_offset_top=50)
-    
+
 
     #-------------------------
     #-- Widgets and callbacks --
@@ -358,7 +359,7 @@ def plotspectra(spectra, zcatalog=None, redrock_cat=None, notebook=False, html_d
                                        show_zcat=show_zcat)
     viewer_widgets.add_specline_toggles(viewer_cds, viewer_plots)
     viewer_widgets.add_model_select(viewer_cds, num_approx_fits, with_full_2ndfit=with_full_2ndfit)
-    
+
     #-----
     #- VI-related widgets
     ## TODO if with_vi_widgets (need to adapt update_plot.js..)
@@ -379,12 +380,12 @@ def plotspectra(spectra, zcatalog=None, redrock_cat=None, notebook=False, html_d
     if (vi_countdown > 0) :
         viewer_vi_widgets.add_countdown(vi_countdown)
 
-    viewer_widgets.add_update_plot_callback(viewer_cds, viewer_plots, 
+    viewer_widgets.add_update_plot_callback(viewer_cds, viewer_plots,
                 viewer_vi_widgets)
 
     #-----
     #- Bokeh layout and output
-    
+
     bokeh_layout = ViewerLayout(viewer_plots, viewer_widgets, viewer_vi_widgets,
                               with_vi_widgets=with_vi_widgets)
     if with_thumb_tab:

--- a/py/prospect/viewer/plots.py
+++ b/py/prospect/viewer/plots.py
@@ -121,8 +121,13 @@ class ViewerPlots(object):
         self.xmin = 100000.
         if survey == 'SDSS':
             bands = ['coadd']
-            self.ymin = np.nanmin(spectra.flux.value[0])
-            self.ymax = np.nanmax(spectra.flux.value[0])
+            try:
+                self.ymin = np.nanmin(spectra.flux.value[0, :])
+                self.ymax = np.nanmax(spectra.flux.value[0, :])
+            except IndexError:
+                # Catch case where, e.g., flux.shape == (3000, ).
+                self.ymin = np.nanmin(spectra.flux.value)
+                self.ymax = np.nanmax(spectra.flux.value)
             self.xmin = np.min(spectra.spectral_axis.value)
             self.xmax = np.max(spectra.spectral_axis.value)
         else:


### PR DESCRIPTION
This PR closes #92.

As a stretch goal for this PR: are there ever cases where we want to mask **DESI** pixels above and beyond cases were inverse variance == 0?  Are there some cases where a mask value should be ignored, versus "definitely do not use this pixel, even if inverse variance != 0", or somewhere in between?