### PR TITLE
Handling a missing arm

### DIFF
--- a/bin/examples_prospect_pages.sh
+++ b/bin/examples_prospect_pages.sh
@@ -319,3 +319,22 @@ if [[ $1 == 16 ]] || [[ $1 == '' ]]; then
                    --targeting_mask STD_BRIGHT \
                    --no_imaging --no_noise --no_vi_widgets
 fi
+
+# -------------------------
+# Some other tests
+#  (those are more tests than useful examples)
+# -------------------------
+
+#- 17) Inspect a single spectrum from daily spectra
+#      Which turns out to have a missing 'r' band
+if [[ $1 == 17 ]] || [[ $1 == '' ]]; then
+    echo "------ Example/Test 17 ------"
+    DATAPATH=${DESI_SPECTRO_REDUX}/daily/tiles/cumulative/1823/20210616
+    OUTPUTDIR=${OUTPUT_ROOT}/17
+    [ ! -d ${OUTPUTDIR} ] && mkdir ${OUTPUTDIR}
+    prospect_pages --spectra_files ${DATAPATH}/coadd-9-1823-thru20210616.fits \
+                   --zcat_files ${DATAPATH}/zbest-9-1823-thru20210616.fits \
+                   --redrock_details_files ${DATAPATH}/redrock-9-1823-thru20210616.h5 \
+                   --targets 39627747886112324 \
+                   --outputdir ${OUTPUTDIR}
+fi

--- a/bin/examples_prospect_pages.sh
+++ b/bin/examples_prospect_pages.sh
@@ -326,7 +326,7 @@ fi
 # -------------------------
 
 #- 17) Inspect a single spectrum from daily spectra
-#      Which turns out to have a missing 'r' band
+#      Which turns out to have a missing 'r' band (spectra.bands = ['b', 'z'])
 if [[ $1 == 17 ]] || [[ $1 == '' ]]; then
     echo "------ Example/Test 17 ------"
     DATAPATH=${DESI_SPECTRO_REDUX}/daily/tiles/cumulative/1823/20210616
@@ -336,5 +336,20 @@ if [[ $1 == 17 ]] || [[ $1 == '' ]]; then
                    --zcat_files ${DATAPATH}/zbest-9-1823-thru20210616.fits \
                    --redrock_details_files ${DATAPATH}/redrock-9-1823-thru20210616.h5 \
                    --targets 39627747886112324 \
+                   --outputdir ${OUTPUTDIR}
+fi
+
+#- 18) A single spectrum from iron spectra
+#      With a completely masked, though existing, 'r' band
+if [[ $1 == 18 ]] || [[ $1 == '' ]]; then
+    echo "------ Example/Test 18 ------"
+    DATAPATH=${DESI_SPECTRO_REDUX}/iron/healpix/main/dark/134/13455
+    OUTPUTDIR=${OUTPUT_ROOT}/18
+    [ ! -d ${OUTPUTDIR} ] && mkdir ${OUTPUTDIR}
+    prospect_pages --spectra_files ${DATAPATH}/coadd-main-dark-13455.fits \
+                   --zcat_files ${DATAPATH}/redrock-main-dark-13455.fits \
+                   --redrock_details_files ${DATAPATH}/rrdetails-main-dark-13455.h5 \
+                   --targets 39628472435347978 \
+                   --no_clean_fiberstatus \
                    --outputdir ${OUTPUTDIR}
 fi

--- a/py/prospect/grid_thumbs.py
+++ b/py/prospect/grid_thumbs.py
@@ -40,7 +40,7 @@ def grid_thumbs(spectra, thumb_width, x_range=(3400,10000), thumb_height=None, r
     for i_spec in range(spectra.num_spectra()) :
         x_vals = (thumb_wave[::resamp_factor])[resamp_factor:-resamp_factor]
         # Use astropy convolution : handles NaNs
-        y_vals = astropy.convolution.convolve(thumb_flux[i_spec,:], kernel)
+        y_vals = astropy.convolution.convolve(thumb_flux[i_spec,:], kernel, nan_treatment='fill')
         y_vals = (y_vals[::resamp_factor])[resamp_factor:-resamp_factor]
         x_vals = x_vals[~np.isnan(y_vals)] # Needed to avoid 'ValueError: Out of range float values are not JSON compliant'
         y_vals = y_vals[~np.isnan(y_vals)]

--- a/py/prospect/js/coadd_brz_cameras.js
+++ b/py/prospect/js/coadd_brz_cameras.js
@@ -3,8 +3,24 @@
 
 function coadd_brz_cameras(wave_in, flux_in, noise_in) {
     // Camera-coadd brz spectra.
-    // each "_in" must have 3 entries (brz)
+    // Coaddition is done only when each "_in" has 3 entries (brz)
     // TODO handle case of no noise
+    var wave_out = []
+    var flux_out = []
+    var noise_out = []
+
+    // Special case of a missing arm (or two)
+    // in that case: just concatenate the data.
+    if (wave_in.length <= 2) {
+        for (var i_cam=0; i_cam<wave_in.length; i_cam++) {
+            for (var i=0; i<wave_in[i_cam].length; i++) {
+                wave_out.push(wave_in[i_cam][i])
+                flux_out.push(flux_in[i_cam][i])
+                noise_out.push(noise_in[i_cam][i])
+            }
+        }
+        return [wave_out, flux_out, noise_out]
+    }
 
     // Find b,r,z ordering in input arrays
     var wave_start = [wave_in[0][0], wave_in[1][0], wave_in[2][0]]
@@ -15,9 +31,6 @@ function coadd_brz_cameras(wave_in, flux_in, noise_in) {
         if ( (i_b != i) && (i_z != i) ) i_r = i
     }
 
-    var wave_out = []
-    var flux_out = []
-    var noise_out = []
     var margin = 20
     for (var i=0; i<wave_in[i_b].length; i++) { // b
         if (wave_in[i_b][i] < wave_in[i_b][wave_in[i_b].length-1] - margin) {

--- a/py/prospect/js/update_plot.js
+++ b/py/prospect/js/update_plot.js
@@ -132,8 +132,8 @@ for (var i=0; i<spectra.length; i++) {
     var data = spectra[i].data;
     var origflux = data['origflux'+String(i_spectrum)];
     if (origflux.filter(isFinite).length == 0) {
-        alert("Spectrum " + (i+1) + " (of " + spectra.length + ") of object " + i_spectrum + " has no valid data!");
-        data["plotflux"] = (function(){ var foo = []; for (var j=0; j<origflux.length; j++) foo.push(1.0); return foo;})();
+        //alert("Spectrum " + (i+1) + " (of " + spectra.length + ") of object " + i_spectrum + " has no valid data!");
+        data["plotflux"] = new Array(origflux.length).fill(0.0);
         if ("plotnoise" in data) data["plotnoise"] = data["plotflux"].slice();
     } else {
         if ('plotnoise' in data) {

--- a/py/prospect/js/update_plot.js
+++ b/py/prospect/js/update_plot.js
@@ -176,7 +176,7 @@ if (coaddcam_spec) {
     var wave_in = [];
     var flux_in = [];
     var noise_in = [];
-    for (var i=0; i<3; i++) {
+    for (var i=0; i<spectra.length; i++) {
         var data = spectra[i].data;
         wave_in.push(data['plotwave'].slice());
         flux_in.push(data['plotflux'].slice());

--- a/py/prospect/utilities.py
+++ b/py/prospect/utilities.py
@@ -198,7 +198,7 @@ def load_redrock_templates(template_dir=None) :
     sys.stdout = open('/dev/null', 'w')
     try:
         templates = dict()
-        for filename in redrock.templates.find_templates(template_dir=template_dir):
+        for filename in redrock.templates.find_templates(template_path=template_dir):
             tx = redrock.templates.Template(filename)
             templates[(tx.template_type, tx.sub_type)] = tx
     except Exception as err:

--- a/py/prospect/viewer/__init__.py
+++ b/py/prospect/viewer/__init__.py
@@ -114,30 +114,51 @@ def create_model(spectra, zcat, archetype_fit=False, archetypes_dir=None, templa
                 mx                  = resample_flux(spectra.wave[band], tx.wave*(1+zb['Z']), model)
                 model_flux[band][i] = spectra.R[band][i].dot(mx)
 
-    #- Now combine, if needed, to a single wavelength grid across all cameras
-    if spectra.bands == ['brz'] :
-        model_wave = spectra.wave['brz']
-        mflux = model_flux['brz']
+    #- Combine, if needed, to a single wavelength grid across all cameras
+    # The following works for any given set of bands
+    keep = dict()
+    meanwaves = [ np.mean(spectra.wave[band]) for band in spectra.bands]  # sort bands by increasing wave
+    sorted_bands = [ x for _,x in sorted(zip(meanwaves, spectra.bands)) ]
+    for i_band, band in enumerate(sorted_bands):
+        wavecut_low = 0
+        wavecut_up = 1.e10
+        if i_band>0:
+            band_low = sorted_bands[i_band-1]
+            wavecut_low = 0.5*(spectra.wave[band_low][-1] + spectra.wave[band][0])
+        if i_band<len(sorted_bands)-1:
+            band_up = sorted_bands[i_band+1]
+            wavecut_up = 0.5*(spectra.wave[band][-1] + spectra.wave[band_up][0])
+        keep[band] = (spectra.wave[band]>wavecut_low) & (spectra.wave[band]<wavecut_up)
+    model_wave = np.concatenate(
+        [ spectra.wave[band][keep[band]] for band in sorted_bands ]
+    )
+    mflux = np.concatenate(
+        [ model_flux[band][:, keep[band]] for band in sorted_bands ],
+    axis=1)
+    
+#     if spectra.bands == ['brz'] :
+#         model_wave = spectra.wave['brz']
+#         mflux = model_flux['brz']
 
-    elif np.all([ band in spectra.bands for band in ['b','r','z'] ]) :
-        br_split = 0.5*(spectra.wave['b'][-1] + spectra.wave['r'][0])
-        rz_split = 0.5*(spectra.wave['r'][-1] + spectra.wave['z'][0])
-        keep = dict()
-        keep['b'] = (spectra.wave['b'] < br_split)
-        keep['r'] = (br_split <= spectra.wave['r']) & (spectra.wave['r'] < rz_split)
-        keep['z'] = (rz_split <= spectra.wave['z'])
-        model_wave = np.concatenate( [
-            spectra.wave['b'][keep['b']],
-            spectra.wave['r'][keep['r']],
-            spectra.wave['z'][keep['z']],
-        ] )
-        mflux = np.concatenate( [
-            model_flux['b'][:, keep['b']],
-            model_flux['r'][:, keep['r']],
-            model_flux['z'][:, keep['z']],
-        ], axis=1 )
-    else :
-        raise RuntimeError("create_model: Set of bands for spectra not supported")
+#     elif np.all([ band in spectra.bands for band in ['b','r','z'] ]) :
+#         br_split = 0.5*(spectra.wave['b'][-1] + spectra.wave['r'][0])
+#         rz_split = 0.5*(spectra.wave['r'][-1] + spectra.wave['z'][0])
+#         keep = dict()
+#         keep['b'] = (spectra.wave['b'] < br_split)
+#         keep['r'] = (br_split <= spectra.wave['r']) & (spectra.wave['r'] < rz_split)
+#         keep['z'] = (rz_split <= spectra.wave['z'])
+#         model_wave = np.concatenate( [
+#             spectra.wave['b'][keep['b']],
+#             spectra.wave['r'][keep['r']],
+#             spectra.wave['z'][keep['z']],
+#         ] )
+#         mflux = np.concatenate( [
+#             model_flux['b'][:, keep['b']],
+#             model_flux['r'][:, keep['r']],
+#             model_flux['z'][:, keep['z']],
+#         ], axis=1 )
+#     else :
+#         raise RuntimeError("create_model: Set of bands for spectra not supported")
 
     return model_wave, mflux
 

--- a/py/prospect/viewer/__init__.py
+++ b/py/prospect/viewer/__init__.py
@@ -135,30 +135,6 @@ def create_model(spectra, zcat, archetype_fit=False, archetypes_dir=None, templa
     mflux = np.concatenate(
         [ model_flux[band][:, keep[band]] for band in sorted_bands ],
     axis=1)
-    
-#     if spectra.bands == ['brz'] :
-#         model_wave = spectra.wave['brz']
-#         mflux = model_flux['brz']
-
-#     elif np.all([ band in spectra.bands for band in ['b','r','z'] ]) :
-#         br_split = 0.5*(spectra.wave['b'][-1] + spectra.wave['r'][0])
-#         rz_split = 0.5*(spectra.wave['r'][-1] + spectra.wave['z'][0])
-#         keep = dict()
-#         keep['b'] = (spectra.wave['b'] < br_split)
-#         keep['r'] = (br_split <= spectra.wave['r']) & (spectra.wave['r'] < rz_split)
-#         keep['z'] = (rz_split <= spectra.wave['z'])
-#         model_wave = np.concatenate( [
-#             spectra.wave['b'][keep['b']],
-#             spectra.wave['r'][keep['r']],
-#             spectra.wave['z'][keep['z']],
-#         ] )
-#         mflux = np.concatenate( [
-#             model_flux['b'][:, keep['b']],
-#             model_flux['r'][:, keep['r']],
-#             model_flux['z'][:, keep['z']],
-#         ], axis=1 )
-#     else :
-#         raise RuntimeError("create_model: Set of bands for spectra not supported")
 
     return model_wave, mflux
 

--- a/py/prospect/viewer/plots.py
+++ b/py/prospect/viewer/plots.py
@@ -134,8 +134,9 @@ class ViewerPlots(object):
                 else:
                     sp_flux = spectra.flux[band][0]
                     sp_wave = spectra.wave[band]
-                self.ymin = min(self.ymin, np.nanmin(sp_flux))
-                self.ymax = max(self.ymax, np.nanmax(sp_flux))
+                if np.isfinite(sp_flux).any():
+                    self.ymin = min(self.ymin, np.nanmin(sp_flux))
+                    self.ymax = max(self.ymax, np.nanmax(sp_flux))
                 self.xmin = min(self.xmin, np.min(sp_wave))
                 self.xmax = max(self.xmax, np.max(sp_wave))
         self.xmin -= self.xmargin_left


### PR DESCRIPTION
- Tiny but urgent update: adapt to change in `redrock.templates.find_templates` (few weeks ago), template_dir now template_path. In order not to disturb users I keep the "template_dir" argument name in prospect's API now. Maybe more updates on new template management will be needed in the near-future?
- Adapt python+javascript code to the case when only one or two bands among 'b' 'r' 'z' are present. The javascript code does not properly coadd overlapping arms in that case, but I think it's good enough, else it requires much more coding and testing in javascript, with possible side effects.
- Improve (python) code when one of the bands, though present, has only masked values.
