### PR TITLE
plotspectra outfile and with_other_model opts

### DIFF
--- a/bin/examples_prospect_pages.sh
+++ b/bin/examples_prospect_pages.sh
@@ -353,3 +353,14 @@ if [[ $1 == 18 ]] || [[ $1 == '' ]]; then
                    --no_clean_fiberstatus \
                    --outputdir ${OUTPUTDIR}
 fi
+
+#- 19) Do not display the 'other model' curve when displaying only spectra
+if [[ $1 == 19 ]] || [[ $1 == '' ]]; then
+    echo "------ Example/Test 19 ------"
+    DATAPATH=${DESI_SPECTRO_REDUX}/iron/tiles/cumulative/81067/20210327
+    OUTPUTDIR=${OUTPUT_ROOT}/19
+    [ ! -d ${OUTPUTDIR} ] && mkdir ${OUTPUTDIR}
+    prospect_pages --spectra_files ${DATAPATH}/coadd-5-81067-thru20210327.fits \
+                   --no_other_model \
+                   -o ${OUTPUTDIR}
+fi

--- a/py/prospect/scripts/prospect_pages.py
+++ b/py/prospect/scripts/prospect_pages.py
@@ -88,6 +88,7 @@ def _parse():
     parser.add_argument('--colors', help="""Customize the curve's colors: 3 colors should be given, associated respectively to the coadded data, the model and the noise.""", nargs='+', type=str, default=None)
     parser.add_argument('--no_imaging', dest='with_imaging', help='Do not include thumb images from https://www.legacysurvey.org/viewer', action='store_false')
     parser.add_argument('--no_noise', dest='with_noise', help='Do not display noise vectors associated to spectra', action='store_false')
+    parser.add_argument('--no_other_model', dest='with_other_model', help="""Do not display the 'other model' curve""", action='store_false')
     parser.add_argument('--no_thumb_tab', dest='with_thumb_tab', help='Do not include a tab with spectra thumbnails', action='store_false')
     parser.add_argument('--no_vi_widgets', dest='with_vi_widgets', help='Do not include widgets used to enter VI information', action='store_false')
     parser.add_argument('--no_coaddcam', dest='with_coaddcam', help='Do not include camera-coaddition (DESI only)', action='store_false')
@@ -300,6 +301,7 @@ def main():
         'colors': args.colors,
         'with_imaging': args.with_imaging,
         'with_noise': args.with_noise,
+        'with_other_model': args.with_other_model,
         'with_thumb_tab': args.with_thumb_tab,
         'with_vi_widgets': args.with_vi_widgets,
         'with_coaddcam': args.with_coaddcam

--- a/py/prospect/viewer/__init__.py
+++ b/py/prospect/viewer/__init__.py
@@ -368,7 +368,7 @@ def plotspectra(spectra, zcatalog=None, redrock_cat=None, notebook=False,
     viewer_widgets.add_metadata_tables(viewer_cds, top_metadata=top_metadata,
                                        show_zcat=show_zcat)
     viewer_widgets.add_specline_toggles(viewer_cds, viewer_plots)
-    if (num_approx_fits is not None and num_approx_fits>0) or with_full_2ndfit:
+    if with_other_model:
         viewer_widgets.add_model_select(viewer_cds, num_approx_fits, with_full_2ndfit=with_full_2ndfit)
 
     #-----


### PR DESCRIPTION
This PR adds two backwards compatible options to plotspectra:
* outfile: specify the name of the output file instead of the default html_dir/title.html (I want to set the title in the plot to be more verbose than I want for the name of the file)
* with_other_model=True; set to False to turn off the other/default model loading

I'm not entirely sure I got the othermodel widget wrangling correct for all cases of the default templates vs. 2nd best fits vs. nothing, so please check how that was intended to work and that I didn't break anything.