### PR TITLE
Only add 2nd Best Fit option if it actually exists

### DIFF
--- a/doc/changes.rst
+++ b/doc/changes.rst
@@ -2,10 +2,12 @@
 prospect's Change Log
 =====================
 
-1.3.3 (unreleased)
+1.3.3 (2024-05-03)
 ------------------
 
-* No changes yet.
+* Fix bug when plotting spectra that don't have a 2nd best fit model (PR `#100`_).
+
+.. _`#100`: https://github.com/desihub/prospect/pull/100
 
 1.3.2 (2024-05-01)
 ------------------

--- a/py/prospect/js/update_plot.js
+++ b/py/prospect/js/update_plot.js
@@ -221,14 +221,17 @@ if (othermodel) {
         othermodel.change.emit();
     } else if (cb_obj == ispectrumslider) {
         // Trick to trigger execution of select_model.js
-        // Reset othermodel to best fit (if there is one). Smoothing is done in select_model.js
+        // Reset othermodel to best fit (if there is one; else dont change it). Smoothing is done in select_model.js
+        var previous_value = model_select.value;
         var trigger_value = model_select.options[0];
-        if (model_select.value == trigger_value) {
+        if (previous_value == trigger_value) {
             trigger_value = model_select.options[1];
         }
         model_select.value = trigger_value;
         if (model_select.options.includes('Best fit')) {
             model_select.value = 'Best fit';
+        } else {
+            model_select.value = previous_value;
         }
     }
 }

--- a/py/prospect/scripts/prospect_pages.py
+++ b/py/prospect/scripts/prospect_pages.py
@@ -93,6 +93,8 @@ def _parse():
     parser.add_argument('--no_vi_widgets', dest='with_vi_widgets', help='Do not include widgets used to enter VI information', action='store_false')
     parser.add_argument('--no_coaddcam', dest='with_coaddcam', help='Do not include camera-coaddition (DESI only)', action='store_false')
     parser.add_argument('--vi_countdown', help='Countdown widget (in minutes)', type=int, default=-1)
+    parser.add_argument('--no_full_2ndfit', dest='with_full_2ndfit', help='Compute and display the second best-fit model without approximation (when available)', action='store_false')
+    parser.add_argument('--num_approx_fits', help='Number of best-fit models to display', type=int, default=4)
 
     #- Filtering at the spectra level
     parser.add_argument('--targeting_mask', help='Filter objects with a given targeting mask.', type=str, default=None)
@@ -294,8 +296,8 @@ def main():
         'top_metadata': args.top_metadata,
         'template_dir': args.template_dir,
         'vi_countdown': args.vi_countdown,
-        'num_approx_fits': None,
-        'with_full_2ndfit': False,
+        'num_approx_fits': args.num_approx_fits,
+        'with_full_2ndfit': args.with_full_2ndfit,
         'with_thumb_only_page': args.with_thumbnail_only_pages,
         'std_template_file': args.std_template_file,
         'colors': args.colors,
@@ -326,8 +328,6 @@ def main():
             if len(zcat_files)!=n_specfiles:
                 raise ValueError('Number of zcat_files does not match number of input spectra_files')
         if redrock_details_files is not None :
-            viewer_params['num_approx_fits'] = 4 # TODO un-hardcode ?
-            viewer_params['with_full_2ndfit'] = True # TODO un-hardcode ?
             if len(redrock_details_files)!=n_specfiles:
                 raise ValueError('Number of redrock_details_files does not match number of input spectra_files')
 
@@ -429,8 +429,6 @@ def main():
             if args.with_multiple_models:
                 spectra, zcat, redrock_cat = load_spectra_zcat_from_targets(targetids, args.datadir, target_db,
                                                     dirtree_type=args.dirtree_type, with_redrock_details=True)
-                viewer_params['num_approx_fits'] = 4 # TODO un-hardcode ?
-                viewer_params['with_full_2ndfit'] = True # TODO un-hardcode ?
             else:
                 spectra, zcat = load_spectra_zcat_from_targets(targetids, args.datadir, target_db,
                                                     dirtree_type=args.dirtree_type, with_redrock_details=False)
@@ -452,9 +450,6 @@ def main():
                 if spectra is None:
                     log.info('No spectra found for this subset')
                     continue
-                if redrock_cat is not None:
-                    viewer_params['num_approx_fits'] = 4 # TODO un-hardcode ?
-                    viewer_params['with_full_2ndfit'] = True # TODO un-hardcode ?
                 #- Associate a subdirectory for each individual subset:
                 html_subdir = dataset+'-'+get_subset_label(db_entry['subset'], args.dirtree_type)
                 viewer_params['html_dir'] = os.path.join(args.outputdir, html_subdir)

--- a/py/prospect/viewer/__init__.py
+++ b/py/prospect/viewer/__init__.py
@@ -369,7 +369,7 @@ def plotspectra(spectra, zcatalog=None, redrock_cat=None, notebook=False,
                                        show_zcat=show_zcat)
     viewer_widgets.add_specline_toggles(viewer_cds, viewer_plots)
     if with_other_model:
-        viewer_widgets.add_model_select(viewer_cds, num_approx_fits, with_full_2ndfit=with_full_2ndfit)
+        viewer_widgets.add_model_select(viewer_cds, num_approx_fits)
 
     #-----
     #- VI-related widgets

--- a/py/prospect/viewer/widgets.py
+++ b/py/prospect/viewer/widgets.py
@@ -22,14 +22,14 @@ from ..utilities import get_resources
 
 def _metadata_table(table_keys, viewer_cds, table_width=500, shortcds_name='shortcds', selectable=False):
     """ Returns bokeh's (ColumnDataSource, DataTable) needed to display a set of metadata given by table_keys.
-    
+
     """
-    special_cell_width = { 'TARGETID':150, 'MORPHTYPE':70, 'SPECTYPE':70, 'SUBTYPE':60, 
+    special_cell_width = { 'TARGETID':150, 'MORPHTYPE':70, 'SPECTYPE':70, 'SUBTYPE':60,
                          'Z':50, 'ZERR':50, 'Z_ERR':50, 'ZWARN':50, 'ZWARNING':50, 'DELTACHI2':70 }
     for x in viewer_cds.phot_bands:
         special_cell_width['mag_'+x] = 40
     special_cell_title = { 'DELTACHI2': 'Δχ2(N+1/N)' }
-    
+
     table_columns = []
     cdsdata = dict()
     for key in table_keys:
@@ -58,20 +58,20 @@ def _metadata_table(table_keys, viewer_cds, table_width=500, shortcds_name='shor
                              index_position=None, selectable=selectable, editable=editable, width=table_width)
     output_table.height = 2 * output_table.row_height
     return (shortcds, output_table)
-    
-    
+
+
 class ViewerWidgets(object):
-    """ 
+    """
     Encapsulates Bokeh widgets, and related callbacks, that are part of prospect's GUI.
         Except for VI widgets
     """
-    
+
     def __init__(self, plots, nspec):
         self.js_files = get_resources('js')
         self.navigation_button_width = 30
         self.z_button_width = 30
         self.plot_widget_width = (plots.plot_width+(plots.plot_height//2))//2 - 40 # used for widgets scaling
-    
+
         #-----
         #- Ispectrumslider and smoothing widgets
         # Ispectrumslider's value controls which spectrum is displayed
@@ -319,15 +319,15 @@ class ViewerWidgets(object):
             """
         )
         self.coaddcam_buttons.js_on_click(self.coaddcam_callback)
-    
-    
+
+
     def add_metadata_tables(self, viewer_cds, show_zcat=True,
                            top_metadata=['TARGETID', 'EXPID', 'COADD_NUMEXP', 'COADD_EXPTIME']):
         """ Display object-related informations
                 top_metadata: metadata to be highlighted in table_a
-            
+
             Note: "short" CDS, with a single row, are used to fill these bokeh tables.
-            When changing object, js code modifies these short CDS so that tables are updated.  
+            When changing object, js code modifies these short CDS so that tables are updated.
         """
 
         #- Sorted list of potential metadata:
@@ -343,10 +343,10 @@ class ViewerWidgets(object):
                     table_keys.append(prefix+'_'+key)
                     if key in top_metadata:
                         top_metadata.append(prefix+'_'+key)
-        
+
         #- Table a: "top metadata"
         table_a_keys = [ x for x in table_keys if x in top_metadata ]
-        self.shortcds_table_a, self.table_a = _metadata_table(table_a_keys, viewer_cds, table_width=600, 
+        self.shortcds_table_a, self.table_a = _metadata_table(table_a_keys, viewer_cds, table_width=600,
                                                               shortcds_name='shortcds_table_a', selectable=True)
         #- Table b: Targeting information
         self.shortcds_table_b, self.table_b = _metadata_table(['Targeting masks'], viewer_cds, table_width=self.plot_widget_width,
@@ -455,7 +455,8 @@ class ViewerWidgets(object):
         model_options = []
         if viewer_cds.cds_model is not None:
             model_options = ['Best fit']
-        if with_full_2ndfit:
+        # if with_full_2ndfit:
+        if viewer_cds.cds_model_2ndfit is not None:
             model_options.append('2nd best fit')
         if num_approx_fits is not None:
             for i in range(1,1+num_approx_fits) :

--- a/py/prospect/viewer/widgets.py
+++ b/py/prospect/viewer/widgets.py
@@ -449,13 +449,12 @@ class ViewerWidgets(object):
         self.majorline_checkbox.js_on_click(self.speclines_callback)
 
 
-    def add_model_select(self, viewer_cds, num_approx_fits, with_full_2ndfit=True):
+    def add_model_select(self, viewer_cds, num_approx_fits):
         #------
         #- Select secondary model to display
         model_options = []
         if viewer_cds.cds_model is not None:
             model_options = ['Best fit']
-        # if with_full_2ndfit:
         if viewer_cds.cds_model_2ndfit is not None:
             model_options.append('2nd best fit')
         if num_approx_fits is not None:

--- a/py/prospect/viewer/widgets.py
+++ b/py/prospect/viewer/widgets.py
@@ -457,7 +457,8 @@ class ViewerWidgets(object):
             model_options = ['Best fit']
         if viewer_cds.cds_model_2ndfit is not None:
             model_options.append('2nd best fit')
-        if num_approx_fits is not None:
+        if num_approx_fits is not None and viewer_cds.dict_rrdetails is not None:
+            # NB approx fits are computed from coefs in detailled redrock file
             for i in range(1,1+num_approx_fits) :
                 ith = 'th'
                 if i==1 : ith='st'


### PR DESCRIPTION
This PR fixes #98.

When Prospect is used with SDSS data or data derived from SPARCL, a 2nd best fit model is not available. However, `ViewerWidgets.add_model_select()` was assuming that it was always available based on `with_full_2ndfit` which defaults to `True`.

This resulted in the JavaScript side of prospect attempting to obtain data from an object that is `null` (a Python `None` converted to JavaScript).

With this change, the argument `with_full_2ndfit` is unused, can it be eliminated from that method entirely?