### PR TITLE
Update testing framework

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -17,7 +17,7 @@ jobs:
             fail-fast: true
             matrix:
                 os: [ubuntu-latest]
-                python-version: ['3.9', '3.12']
+                python-version: ['3.10', '3.12']
 
         steps:
             - name: Checkout code

--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -17,7 +17,7 @@ jobs:
             fail-fast: true
             matrix:
                 os: [ubuntu-latest]
-                python-version: ['3.8', '3.9']
+                python-version: ['3.9', '3.12']
 
         steps:
             - name: Checkout code

--- a/py/prospect/test/test_top_level.py
+++ b/py/prospect/test/test_top_level.py
@@ -33,9 +33,3 @@ class TestTopLevel(unittest.TestCase):
         self.assertRegex(theVersion, self.versionre)
 
 
-def test_suite():
-    """Allows testing of only this module with the command::
-
-        python setup.py test -m <modulename>
-    """
-    return unittest.defaultTestLoader.loadTestsFromName(__name__)

--- a/py/prospect/test/test_utilities.py
+++ b/py/prospect/test/test_utilities.py
@@ -5,7 +5,6 @@
 import unittest
 import re
 import sys
-from pkg_resources import resource_filename
 from ..utilities import vi_file_fields, get_resources
 
 
@@ -37,9 +36,3 @@ class TestUtilities(unittest.TestCase):
             bad = get_resources('foo')
 
 
-def test_suite():
-    """Allows testing of only this module with the command::
-
-        python setup.py test -m <modulename>
-    """
-    return unittest.defaultTestLoader.loadTestsFromName(__name__)

--- a/py/prospect/test/test_utilities.py
+++ b/py/prospect/test/test_utilities.py
@@ -31,7 +31,13 @@ class TestUtilities(unittest.TestCase):
         """Test caching of resource files.
         """
         foo = get_resources('templates')
+        self.assertIn('template_index.html', foo.keys())
+        self.assertIsInstance(foo['template_index.html'], str)
+
         bar = get_resources('js')
+        self.assertIn('FileSaver.js', bar.keys())
+        self.assertIsInstance(bar['FileSaver.js'], str)
+
         with self.assertRaises(ValueError):
             bad = get_resources('foo')
 

--- a/py/prospect/utilities.py
+++ b/py/prospect/utilities.py
@@ -9,7 +9,7 @@ Utility functions for prospect.
 """
 
 import os, glob, sys
-from pkg_resources import resource_string, resource_listdir
+import importlib.resources
 
 import numpy as np
 import astropy.io.fits
@@ -159,9 +159,11 @@ def get_resources(filetype):
         raise ValueError("Unknown filetype '{0}' for get_resources()!".format(filetype))
     if _resource_cache[filetype] is None:
         _resource_cache[filetype] = dict()
-        for f in resource_listdir('prospect', filetype):
-            if not f.startswith("."):
-                _resource_cache[filetype][f] = resource_string('prospect', filetype + '/' + f).decode('utf-8')
+        for f in importlib.resources.files('prospect').joinpath(filetype).iterdir():
+            if not f.name.startswith('.'):
+                with open(f) as fp:
+                    _resource_cache[filetype][f] = fp.read()
+
     return _resource_cache[filetype]
 
 

--- a/py/prospect/utilities.py
+++ b/py/prospect/utilities.py
@@ -162,7 +162,7 @@ def get_resources(filetype):
         for f in importlib.resources.files('prospect').joinpath(filetype).iterdir():
             if not f.name.startswith('.'):
                 with open(f) as fp:
-                    _resource_cache[filetype][f] = fp.read()
+                    _resource_cache[filetype][f.name] = fp.read()
 
     return _resource_cache[filetype]
 

--- a/setup.py
+++ b/setup.py
@@ -69,7 +69,6 @@ setup_keywords['cmdclass'] = {'sdist': DistutilsSdist}
 if have_desiutil:
     setup_keywords['cmdclass']['module_file'] = ds.DesiModule
     setup_keywords['cmdclass']['version'] = ds.DesiVersion
-    setup_keywords['cmdclass']['test'] = ds.DesiTest
     setup_keywords['cmdclass']['api'] = ds.DesiAPI
 setup_keywords['test_suite']='{name}.test.{name}_test_suite'.format(**setup_keywords)
 #


### PR DESCRIPTION
This PR drops DesiTest from setup.py so that it is compatible with the latest desiutil. This now requires testing with "pytest" instead of "python setup.py test".  It removes deprecated `test_suite` functions that were generating warnings, and replaces `pkg_resources` with the equivalent `importlib.resources` functionality.

This requires dropping support for python 3.8 since `importlib.resources.files` was introduced in 3.9.  If there is a compelling reason to keep 3.8 support, we could probably find a workaround but I think 3.9 is fine.  I added a test for 3.12.