### PR TITLE
Change maximum z of redshift slider

### DIFF
--- a/bin/examples_prospect_pages.sh
+++ b/bin/examples_prospect_pages.sh
@@ -249,7 +249,8 @@ if [[ $1 == 12 ]] || [[ $1 == '' ]]; then
                    --tiles 81062 80654 \
                    --target_list ${TARGET_LIST_FILE} \
                    --mask_type DESI_TARGET \
-                   --top_metadata TARGETID TILEID COADD_EXPTIME
+                   --top_metadata TARGETID TILEID COADD_EXPTIME \
+                   --zmax_slider 3.5
     rm -f ${TARGET_LIST_FILE}
 fi
 

--- a/py/prospect/js/change_redshift.js
+++ b/py/prospect/js/change_redshift.js
@@ -5,7 +5,7 @@
 //           line_labels, zlines, zline_labels, overlap_waves, overlap_bands, fig.
 
 var z = parseFloat(z_input.value)
-if ( z >=-0.1 && z <= 5.0 ) {
+if ( z >= zslider.start && z <= zslider.end ) {
     // update zsliders only if needed (avoid recursive call)
     z_input.value = parseFloat(z_input.value).toFixed(4)
     var z1 = Math.floor(z*100) / 100
@@ -14,8 +14,8 @@ if ( z >=-0.1 && z <= 5.0 ) {
     if ( Math.abs(z1-zslider.value) >= 0.00999999 ) zslider.value = parseFloat(parseFloat(z1).toFixed(2))
     if ( Math.abs(z2-dzslider.value) >= 0.00009999 ) dzslider.value = parseFloat(parseFloat(z2).toFixed(4))
 } else {
-    if (z_input.value < -0.1) z_input.value = (-0.1).toFixed(4)
-    if (z_input.value > 5) z_input.value = (5.0).toFixed(4)
+    if (z_input.value < zslider.start) z_input.value = (zslider.start).toFixed(4)
+    if (z_input.value > zslider.end) z_input.value = (zslider.end).toFixed(4)
 }
 z = parseFloat(z_input.value)
 

--- a/py/prospect/scripts/prospect_pages.py
+++ b/py/prospect/scripts/prospect_pages.py
@@ -95,6 +95,7 @@ def _parse():
     parser.add_argument('--vi_countdown', help='Countdown widget (in minutes)', type=int, default=-1)
     parser.add_argument('--no_full_2ndfit', dest='with_full_2ndfit', help='Compute and display the second best-fit model without approximation (when available)', action='store_false')
     parser.add_argument('--num_approx_fits', help='Number of best-fit models to display', type=int, default=4)
+    parser.add_argument('--zmax_slider', help='Maximum range of the redshift slider widget', type=float, default=5.0)
 
     #- Filtering at the spectra level
     parser.add_argument('--targeting_mask', help='Filter objects with a given targeting mask.', type=str, default=None)
@@ -306,7 +307,8 @@ def main():
         'with_other_model': args.with_other_model,
         'with_thumb_tab': args.with_thumb_tab,
         'with_vi_widgets': args.with_vi_widgets,
-        'with_coaddcam': args.with_coaddcam
+        'with_coaddcam': args.with_coaddcam,
+        'zmax_slider': args.zmax_slider
     }
 
 

--- a/py/prospect/viewer/__init__.py
+++ b/py/prospect/viewer/__init__.py
@@ -147,7 +147,7 @@ def plotspectra(spectra, zcatalog=None, redrock_cat=None, notebook=False,
                 model_from_zcat=True, model=None, with_other_model=True,
                 num_approx_fits=None, with_full_2ndfit=True,
                 template_dir=None, archetype_fit=False, archetypes_dir=None,
-                std_template_file=None):
+                std_template_file=None, zmax_slider=5.0):
     '''Main prospect routine. From a set of spectra, creates a bokeh document
     used for VI, to be displayed as an HTML page or within a Jupyter notebook.
 
@@ -215,6 +215,8 @@ def plotspectra(spectra, zcatalog=None, redrock_cat=None, notebook=False,
         Directory path for archetypes if not :envvar:`RR_ARCHETYPE_DIR`.
     std_template_file : :class:`str`, optional
         File containing standard templates to display in viewer.
+    zmax_slider : :class:`float`, optional
+        Maximum range of the redshift slider widget.
     '''
 
     #- Check input spectra.
@@ -353,7 +355,7 @@ def plotspectra(spectra, zcatalog=None, redrock_cat=None, notebook=False,
     viewer_widgets.add_navigation(nspec)
     viewer_widgets.add_resetrange(viewer_cds, viewer_plots)
 
-    viewer_widgets.add_redshift_widgets(z, viewer_cds, viewer_plots)
+    viewer_widgets.add_redshift_widgets(z, viewer_cds, viewer_plots, zmax_slider)
     viewer_widgets.add_oii_widgets(viewer_plots)
 
     viewer_plots.add_imfig_callback(viewer_widgets)

--- a/py/prospect/viewer/widgets.py
+++ b/py/prospect/viewer/widgets.py
@@ -140,20 +140,19 @@ class ViewerWidgets(object):
             code = reset_plotrange_code)
         self.reset_plotrange_button.js_on_event('button_click', self.reset_plotrange_callback)
 
-    def add_redshift_widgets(self, z, viewer_cds, plots):
+    def add_redshift_widgets(self, z, viewer_cds, plots, zmax_slider):
         ## TODO handle "z" (same issue as viewerplots TBD)
 
         #-----
         #- Redshift / wavelength scale widgets
         z1 = np.floor(z*100)/100
         dz = z-z1
-        self.zslider = Slider(start=-0.1, end=5.0, value=z1, step=0.01, title='Redshift rough tuning')
+        self.zslider = Slider(start=-0.1, end=round(zmax_slider, 2), value=z1, step=0.01, title='Redshift rough tuning')
         self.dzslider = Slider(start=0.0, end=0.0099, value=dz, step=0.0001, title='Redshift fine-tuning')
         self.zslider.format = "0[.]00" # default bokeh value, for record
         self.dzslider.format = "0[.]0000"
         self.z_input = TextInput(value="{:.4f}".format(z), title="Redshift value:")
         self.cds_widgetinfos.data['z_input_value'][0] = self.z_input.value
-
         #- Observer vs. Rest frame wavelengths
         self.waveframe_buttons = RadioButtonGroup(
             labels=["Obs", "Rest"], active=0)
@@ -165,7 +164,7 @@ class ViewerWidgets(object):
             //   2) out-of-range zslider values (should never happen in principle)
             var z1 = Math.floor(parseFloat(z_input.value)*100) / 100
             if ( (Math.abs(zslider.value-z1) >= 0.01) &&
-                 (zslider.value >= -0.1) && (zslider.value <= 5.0) ){
+                 (zslider.value >= zslider.start) && (zslider.value <= zslider.end) ){
                  var new_z = zslider.value + dzslider.value
                  z_input.value = new_z.toFixed(4)
                 }
@@ -190,19 +189,19 @@ class ViewerWidgets(object):
         self.z_minus_button = Button(label="<", width=self.z_button_width)
         self.z_plus_button = Button(label=">", width=self.z_button_width)
         self.z_minus_callback = CustomJS(
-            args=dict(z_input=self.z_input),
+            args=dict(z_input=self.z_input, zslider=self.zslider),
             code="""
             var z = parseFloat(z_input.value)
-            if(z >= -0.09) {
+            if(z >= zslider.start + 0.01) {
                 z -= 0.01
                 z_input.value = z.toFixed(4)
             }
             """)
         self.z_plus_callback = CustomJS(
-            args=dict(z_input=self.z_input),
+            args=dict(z_input=self.z_input, zslider=self.zslider),
             code="""
             var z = parseFloat(z_input.value)
-            if(z <= 4.99) {
+            if(z <= zslider.end - 0.01) {
                 z += 0.01
                 z_input.value = z.toFixed(4)
             }


### PR DESCRIPTION
Following a request by email from Anniek Gloudemans.
The slider "zslider" to vary redshift had its maximum z fixed to 5.0. Now one can change it:
- run `prospect_pages --zmax_slider 7.0`
- call (in notebook) `viewer.plotspectra(..., zmax_slider=7.0)`

