### PR TITLE
use redrock.templates.load_templates_from_header

### DIFF
--- a/doc/changes.rst
+++ b/doc/changes.rst
@@ -7,8 +7,10 @@ prospect's Change Log
 
 * Updating testing framework for compatibility with desiutil 3.5.x and pytest.
   Requires using ``pytest`` instead of ``python setup.py test``.  (PR `#105`_).
+* Option to change the maximal redshift of the slider widget (PR `#106`_).
 
 .. _`#105`: https://github.com/desihub/prospect/pull/105
+.. _`#106`: https://github.com/desihub/prospect/pull/106
 
 1.3.3 (2024-05-03)
 ------------------

--- a/py/prospect/utilities.py
+++ b/py/prospect/utilities.py
@@ -191,18 +191,24 @@ def file_or_gz_exists(fname):
     return one_exists
 
 
-def load_redrock_templates(template_dir=None) :
+def load_redrock_templates(template_dir=None, zcat_header=None) :
     '''
     Load redrock templates; redirect stdout because redrock is chatty
+
+    Optional zcat_header is header from redrock output with TEMNAMnn/TEMVERnn
+    keywords indicating the template versions used at the time of the fit.
     '''
     assert _redrock_imported
     saved_stdout = sys.stdout
     sys.stdout = open('/dev/null', 'w')
     try:
-        templates = dict()
-        for filename in redrock.templates.find_templates(template_path=template_dir):
-            tx = redrock.templates.Template(filename)
-            templates[(tx.template_type, tx.sub_type)] = tx
+        if zcat_header is not None:
+            #- Load the version of the templates that match the versions recorded in the header
+            templates = redrock.templates.load_templates_from_header(zcat_header, template_dir=template_dir, asdict=True)
+        else:
+            #- Load the default versions
+            templates = redrock.templates.load_templates(template_dir, asdict=True)
+
     except Exception as err:
         sys.stdout = saved_stdout
         raise(err)

--- a/py/prospect/viewer/__init__.py
+++ b/py/prospect/viewer/__init__.py
@@ -77,10 +77,16 @@ def create_model(spectra, zcat, archetype_fit=False, archetypes_dir=None, templa
     if np.any(zcat['TARGETID'] != spectra.fibermap['TARGETID']) :
         raise ValueError('zcatalog and spectra do not match (different targetids)')
 
+    #- Get template versions from header if possible
+    if hasattr(zcat, 'meta') and ('TEMNAM00' in zcat.meta):
+        zcat_header = zcat.meta
+    else:
+        zcat_header = None
+
     if archetype_fit:
         archetypes = All_archetypes(archetypes_dir=archetypes_dir).archetypes
     else:
-        templates = load_redrock_templates(template_dir=template_dir)
+        templates = load_redrock_templates(template_dir=template_dir, zcat_header=zcat_header)
 
     #- Empty model flux arrays per band to fill
     model_flux = dict()
@@ -309,9 +315,15 @@ def plotspectra(spectra, zcatalog=None, redrock_cat=None, notebook=False,
         if zcatalog is None :
             raise ValueError('Redrock_cat was provided but not zcatalog.')
 
+        #- Get template versions from header if possible
+        if hasattr(redrock_cat, 'meta') and ('TEMNAM00' in redrock_cat.meta):
+            zcat_header = redrock_cat.meta
+        else:
+            zcat_header = None
+
         if num_approx_fits!=0 :
             # TODO un-hardcode nbpts_templates ?
-            viewer_cds.load_fit_templates(template_dir=template_dir, nbpts_templates=4000)
+            viewer_cds.load_fit_templates(template_dir=template_dir, nbpts_templates=4000, zcat_header=zcat_header)
         viewer_cds.load_rrdetails(redrock_cat)
         #- define num_approx_fits, used in the "model_select" widget:
         nfits_redrock_cat = viewer_cds.dict_rrdetails['Nfit']

--- a/py/prospect/viewer/cds.py
+++ b/py/prospect/viewer/cds.py
@@ -194,16 +194,18 @@ class ViewerCDS(object):
         })
 
 
-    def load_fit_templates(self, template_dir=None, nbpts_templates=4000):
+    def load_fit_templates(self, template_dir=None, nbpts_templates=4000, zcat_header=None):
         """ Create dict for spectral templates used in Redrock fits.
             These are used to recompute Redrock's Nth best-fit spectra on-the-fly
             in javascript.
             Templates are resampled in order to limit the size of html pages (and the
             browser's CPU usage).
             This resampling is dictated by parameter nbpts_templates.
+            zcat_header is header from Redrock output with TEMNAMnn/TEMVERnn keywords
+            indicating the version of the templates used at the time of the fit.
         """
         assert _desispec_imported # for resample_flux
-        rr_templts = load_redrock_templates(template_dir=template_dir)
+        rr_templts = load_redrock_templates(template_dir=template_dir, zcat_header=zcat_header)
         self.dict_fit_templates = dict()
         for key,templt in rr_templts.items():
             fulltype_key = "_".join(key)   # merge redrock's (TYPE, SUBTYPE)


### PR DESCRIPTION
## Context

When Prospect was originally written, it assumed that you had $RR_TEMPLATE_DIR set to the version of the Redrock templates that were used when the Redrock fits were performed.  That's fine for a single production, but is a pain when you want to generate Prospect files for data from multiple productions that used different templates.

Recent versions of redrock-templates contain all past versions of the individual templates, and Redrock output records the versions used via the TEMNAMnn/TEMVERnn keywords.  This PR updates `prospect.utilities.load_redrock_templates` to use `redrock.templates.load_templates_from_header`, which uses those header keywords of a redshift catalog to know which version of the templates was used at the time of the fit and load the appropriate templates.  This requires redrock>=0.20.2, released Aug 15 2024.

## Example

Fuji used an earlier QSO template that wasn't yet split by HIZ/LOZ.  The following code crashes with prospect/main + redrock-templates/main due to loading the wrong QSO templates.  With this PR it loads the correct templates for fuji vs. loa and generates the appropriate models for each, without having to maintain separate copies of redrock-templates for each of the older tags.
```
from astropy.table import Table
from astropy.io import fits
from desispec.io import read_spectra
from prospect.viewer import plotspectra

reduxdir = os.environ['DESI_SPECTRO_REDUX']
fujidir = f'{reduxdir}/fuji/healpix/sv3/dark/91/9150'
loadir = f'{reduxdir}/loa/healpix/sv3/dark/91/9150'

coaddfilename = 'coadd-sv3-dark-9150.fits'
redrockfilename = 'redrock-sv3-dark-9150.fits'

fujispec = read_spectra(f'{fujidir}/{coaddfilename}')
fujizcat = Table.read(f'{fujidir}/{redrockfilename}', 'REDSHIFTS')
hdr = fits.getheader(f'{fujidir}/{redrockfilename}')
fujizcat.meta.update(hdr)

loaspec = read_spectra(f'{loadir}/{coaddfilename}')
loazcat = Table.read(f'{loadir}/{redrockfilename}', 'REDSHIFTS')
hdr = fits.getheader(f'{loadir}/{redrockfilename}')
# detail: loa also kept headers in REDSHIFTS HDU so this isn't necessary, but do it for symmetry with fuji
loazcat.meta.update(hdr)

#- index range ensures that we have some QSOs
plotspectra(fujispec[80:85], fujizcat[80:85], outfile='fujispec.html')  # Crashes with prospect/main
plotspectra(loaspec[80:85], loazcat[80:85], outfile='loaspec.html')


