### PR TITLE
Support specutils > 2.0

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -40,7 +40,7 @@ jobs:
             - name: Install Python dependencies
               run: |
                 python -m pip install --upgrade pip setuptools wheel
-                python -m pip install "specutils${{ specutils-version }}" "bokeh${{ bokeh-version }}"
+                python -m pip install "specutils${{ matrix.specutils-version }}" "bokeh${{ matrix.bokeh-version }}"
                 python -m pip install --upgrade-strategy only-if-needed --editable .[test]
             - name: Run the test
               run: pytest

--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -16,20 +16,32 @@ jobs:
         strategy:
             fail-fast: true
             matrix:
-                os: [ubuntu-latest]
-                python-version: ['3.11', '3.12', '3.13']
+                include:
+                    - os: ubuntu-latest
+                      python-version: '3.13'
+                      specutils-version: '<3.0'
+                      bokeh-version: '<4'
+                    - os: ubuntu-latest
+                      python-version: '3.12'
+                      specutils-version: '<2.3'
+                      bokeh-version: '<3.5'
+                    - os: ubuntu-latest
+                      python-version: '3.11'
+                      specutils-version: '<2.1'
+                      bokeh-version: '<3.2'
 
         steps:
             - name: Checkout code
-              uses: actions/checkout@v4
+              uses: actions/checkout@v6
             - name: Set up Python ${{ matrix.python-version }}
-              uses: actions/setup-python@v5
+              uses: actions/setup-python@v6
               with:
                 python-version: ${{ matrix.python-version }}
             - name: Install Python dependencies
               run: |
                 python -m pip install --upgrade pip setuptools wheel
-                python -m pip install --editable .[test]
+                python -m pip install "specutils${{ specutils-version }}" "bokeh${{ bokeh-version }}"
+                python -m pip install --upgrade-strategy only-if-needed --editable .[test]
             - name: Run the test
               run: pytest
 
@@ -37,16 +49,16 @@ jobs:
         name: Test coverage
         runs-on: ${{ matrix.os }}
         strategy:
-            fail-fast: true
+            fail-fast: false
             matrix:
                 os: [ubuntu-latest]
                 python-version: ['3.10']
 
         steps:
             - name: Checkout code
-              uses: actions/checkout@v4
+              uses: actions/checkout@v6
             - name: Set up Python ${{ matrix.python-version }}
-              uses: actions/setup-python@v5
+              uses: actions/setup-python@v6
               with:
                 python-version: ${{ matrix.python-version }}
             - name: Install Python dependencies
@@ -54,15 +66,8 @@ jobs:
                 python -m pip install --upgrade pip setuptools wheel
                 python -m pip install numpy\<2.0 specutils\<1.15 bokeh\<3.0
                 python -m pip install --upgrade-strategy only-if-needed --editable .[coverage]
-            - name: Install additional DESI software
-              env:
-                DESITARGET_VERSION: 2.9.0
-                DESISPEC_VERSION: 0.69.0
-                REDROCK_VERSION: 0.20.4
-              run: |
-                python -m pip install git+https://github.com/desihub/desitarget.git@${DESITARGET_VERSION}
-                python -m pip install git+https://github.com/desihub/desispec.git@${DESISPEC_VERSION}
-                python -m pip install git+https://github.com/desihub/redrock.git@${REDROCK_VERSION}
+            - name: Install DESI dependencies
+              run: python -m pip install desitarget desispec redrock
             - name: Run the test with coverage
               run: pytest --cov
             - name: Coveralls
@@ -78,13 +83,13 @@ jobs:
             fail-fast: false
             matrix:
                 os: [ubuntu-latest]
-                python-version: ['3.12']
+                python-version: ['3.13']
 
         steps:
             - name: Checkout code
-              uses: actions/checkout@v4
+              uses: actions/checkout@v6
             - name: Set up Python ${{ matrix.python-version }}
-              uses: actions/setup-python@v5
+              uses: actions/setup-python@v6
               with:
                 python-version: ${{ matrix.python-version }}
             - name: Install Python dependencies
@@ -105,19 +110,17 @@ jobs:
 
         steps:
             - name: Checkout code
-              uses: actions/checkout@v4
+              uses: actions/checkout@v6
               with:
                 fetch-depth: 0
             - name: Set up Python ${{ matrix.python-version }}
-              uses: actions/setup-python@v5
+              uses: actions/setup-python@v6
               with:
                 python-version: ${{ matrix.python-version }}
             - name: Install Python dependencies
               run: python -m pip install --upgrade pip setuptools wheel
             - name: Install DESI dependencies
-              env:
-                DESIUTIL_VERSION: 3.5.2
-              run: python -m pip install desiutil==${DESIUTIL_VERSION}
+              run: python -m pip install desiutil
             - name: Generate api.rst
               run: desi_api_file --api ./api.rst prospect
             - name: Compare generated api.rst to checked-in version
@@ -130,13 +133,13 @@ jobs:
             fail-fast: false
             matrix:
                 os: [ubuntu-latest]
-                python-version: ['3.12']
+                python-version: ['3.13']
 
         steps:
             - name: Checkout code
-              uses: actions/checkout@v4
+              uses: actions/checkout@v6
             - name: Set up Python ${{ matrix.python-version }}
-              uses: actions/setup-python@v5
+              uses: actions/setup-python@v6
               with:
                 python-version: ${{ matrix.python-version }}
             - name: Install Python dependencies

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -46,6 +46,7 @@ intersphinx_mapping = {
     # 'matplotlib': ('https://matplotlib.org/stable/', None),
     'astropy': ('https://docs.astropy.org/en/stable/', None),
     # 'h5py': ('https://docs.h5py.org/en/latest/', None),
+    'specutils': ('https://specutils.readthedocs.io/en/stable/', None),
     'bokeh': ('https://docs.bokeh.org/en/latest/', None)
     }
 

--- a/doc/nb/Prospect_spectrum_service.ipynb
+++ b/doc/nb/Prospect_spectrum_service.ipynb
@@ -29,7 +29,7 @@
     "import numpy as np\n",
     "import astropy.units as u\n",
     "from astropy.nddata import InverseVariance\n",
-    "from specutils import __version__ as specutils_version, Spectrum1D\n",
+    "from specutils import __version__ as specutils_version, Spectrum\n",
     "from prospect import __version__ as prospect_version\n",
     "from prospect.viewer import plotspectra\n",
     "from prospect.specutils import Spectra\n",
@@ -205,7 +205,7 @@
     "\n",
     "Prospect needs several inputs:\n",
     "\n",
-    "1. An object containing spectra.  In this case we'll use [`prospect.specutils.Spectra`](https://desi-prospect.readthedocs.io/en/latest/api.html#prospect.specutils.Spectra), which inherits from [`SpectrumList`](https://specutils.readthedocs.io/en/stable/api/specutils.SpectrumList.html#specutils.SpectrumList), and is really just a [`Spectrum1D`](https://specutils.readthedocs.io/en/stable/api/specutils.Spectrum1D.html#specutils.Spectrum1D) object underneath.\n",
+    "1. An object containing spectra.  In this case we'll use [`prospect.specutils.Spectra`](https://desi-prospect.readthedocs.io/en/latest/api.html#prospect.specutils.Spectra), which inherits from [`SpectrumList`](https://specutils.readthedocs.io/en/stable/api/specutils.SpectrumList.html#specutils.SpectrumList), and is really just a [`Spectrum`](https://specutils.readthedocs.io/en/stable/api/specutils.Spectrum.html#specutils.Spectrum) object underneath.\n",
     "   * The object contains the usual flux, wavelength, uncertainty.\n",
     "   * In addtion a \"fibermap\" table is needed. This should be an Astropy `Table` with the expected columns.\n",
     "2. A redshift catalog. This should be an Astropy `Table` with the expected columns.\n",
@@ -556,7 +556,7 @@
     "\n",
     "Prospect needs several inputs:\n",
     "\n",
-    "1. An object containing spectra.  In this case we'll use a [`Spectrum1D`](https://specutils.readthedocs.io/en/stable/api/specutils.Spectrum1D.html#specutils.Spectrum1D) object.\n",
+    "1. An object containing spectra.  In this case we'll use a [`Spectrum`](https://specutils.readthedocs.io/en/stable/api/specutils.Spectrum.html#specutils.Spectrum) object.\n",
     "   * The object contains the usual flux, wavelength, uncertainty.\n",
     "   * In addtion a \"plugmap\" table is needed. This should be an Astropy `Table` with the expected columns.\n",
     "2. A redshift catalog. This should be an Astropy `Table` with the expected columns.\n",
@@ -653,11 +653,11 @@
    },
    "outputs": [],
    "source": [
-    "sdss_prospect = Spectrum1D(flux=flux * u.Unit('1e-17 erg / (Angstrom cm2 s)'),\n",
-    "                           spectral_axis=sdss_spectra.records[0].wavelength * u.Unit('Angstrom'),\n",
-    "                           uncertainty=InverseVariance(uncertainty),\n",
-    "                           mask=mask != 0,\n",
-    "                           meta=meta)"
+    "sdss_prospect = Spectrum(flux=flux * u.Unit('1e-17 erg / (Angstrom cm2 s)'),\n",
+    "                         spectral_axis=sdss_spectra.records[0].wavelength * u.Unit('Angstrom'),\n",
+    "                         uncertainty=InverseVariance(uncertainty),\n",
+    "                         mask=mask != 0,\n",
+    "                         meta=meta)"
    ]
   },
   {
@@ -855,7 +855,7 @@
     "\n",
     "Prospect needs several inputs:\n",
     "\n",
-    "1. An object containing spectra.  In this case we'll use a [`Spectrum1D`](https://specutils.readthedocs.io/en/stable/api/specutils.Spectrum1D.html#specutils.Spectrum1D) object.\n",
+    "1. An object containing spectra.  In this case we'll use a [`Spectrum`](https://specutils.readthedocs.io/en/stable/api/specutils.Spectrum.html#specutils.Spectrum) object.\n",
     "   * The object contains the usual flux, wavelength, uncertainty.\n",
     "   * In addtion a \"plugmap\" table is needed. This should be an Astropy `Table` with the expected columns.\n",
     "2. A redshift catalog. This should be an Astropy `Table` with the expected columns.\n",
@@ -964,11 +964,11 @@
    },
    "outputs": [],
    "source": [
-    "boss_prospect = Spectrum1D(flux=flux * u.Unit('1e-17 erg / (Angstrom cm2 s)'),\n",
-    "                           spectral_axis=boss_spectra.records[0].wavelength * u.Unit('Angstrom'),\n",
-    "                           uncertainty=InverseVariance(uncertainty),\n",
-    "                           mask=mask != 0,\n",
-    "                           meta=meta)"
+    "boss_prospect = Spectrum(flux=flux * u.Unit('1e-17 erg / (Angstrom cm2 s)'),\n",
+    "                         spectral_axis=boss_spectra.records[0].wavelength * u.Unit('Angstrom'),\n",
+    "                         uncertainty=InverseVariance(uncertainty),\n",
+    "                         mask=mask != 0,\n",
+    "                         meta=meta)"
    ]
   },
   {

--- a/doc/nb/Prospect_specutils.ipynb
+++ b/doc/nb/Prospect_specutils.ipynb
@@ -31,7 +31,6 @@
     "# import os\n",
     "import numpy as np\n",
     "from astropy.table import Table\n",
-    "from specutils import Spectrum1D, SpectrumCollection, SpectrumList\n",
     "from prospect.specutils import read_spectra, read_spPlate, read_spZbest\n",
     "from prospect.viewer import plotspectra"
    ]
@@ -42,7 +41,7 @@
    "source": [
     "## DESI spectra file\n",
     "\n",
-    "DESI spectra are stored by \"channel\" (\"channel\", \"band\" and \"spectrograph arm\" are used interchangably).  There are 10 spectrographs, each with three arms, called 'b', 'r' & 'z'.  In a DESI spectra file, all arms are grouped together, with a common wavelength solution for each arm, but the solutions do not overlap or have the same shape.  Thus we can't use a Spectrum1D or SpectrumCollection object, but we can use a SpectrumList containing three Spectrum1D objects."
+    "DESI spectra are stored by \"channel\" (\"channel\", \"band\" and \"spectrograph arm\" are used interchangably).  There are 10 spectrographs, each with three arms, called 'b', 'r' & 'z'.  In a DESI spectra file, all arms are grouped together, with a common wavelength solution for each arm, but the solutions do not overlap or have the same shape.  Thus we can't use a `Spectrum` or `SpectrumCollection` object, but we can use a `SpectrumList` containing three `Spectrum` objects."
    ]
   },
   {
@@ -70,7 +69,7 @@
    "source": [
     "## SDSS/eBOSS spPlate file\n",
     "\n",
-    "SDSS spectra are stored per-plate in spPlate files.  These contain 640 spectra for the original SDSS spectrograph or 1000 spectra for the BOSS/eBOSS spectrograph.  All spPlate files have a common wavelength solution, so a spPlate file can be represented by a Spectrum1D object."
+    "SDSS spectra are stored per-plate in spPlate files.  These contain 640 spectra for the original SDSS spectrograph or 1000 spectra for the BOSS/eBOSS spectrograph.  All spPlate files have a common wavelength solution, so a spPlate file can be represented by a `Spectrum` object."
    ]
   },
   {

--- a/py/prospect/grid_thumbs.py
+++ b/py/prospect/grid_thumbs.py
@@ -27,7 +27,7 @@ def grid_thumbs(spectra, thumb_width, x_range=(3400, 10000), thumb_height=None,
     - smooth+resample to reduce size of embedded CDS, according to resamp_factor
     - titles : optional list of titles for each thumb
 
-    TODO: Not tested on Spectrum1D objects.
+    TODO: Not tested on :class:`~specutils.Spectrum` objects.
     '''
 
     if thumb_height is None:

--- a/py/prospect/specutils.py
+++ b/py/prospect/specutils.py
@@ -20,6 +20,7 @@ from specutils import SpectrumList
 try:
     from specutils import Spectrum
 except ImportError:
+    # support specutils 1.x
     from specutils import Spectrum1D as Spectrum
 
 _desiutil_imported = True

--- a/py/prospect/specutils.py
+++ b/py/prospect/specutils.py
@@ -16,7 +16,11 @@ from astropy.nddata import InverseVariance
 from astropy.io import fits
 from astropy.table import Table
 from astropy.wcs import WCS
-from specutils import SpectrumList, Spectrum1D
+from specutils import SpectrumList
+try:
+    from specutils import Spectrum
+except ImportError:
+    from specutils import Spectrum1D as Spectrum
 
 _desiutil_imported = True
 try:
@@ -157,11 +161,11 @@ class Spectra(SpectrumList):
                 band_meta['extra'] = dict()
                 for k, v in extra[b].items():
                     band_meta['extra'][k] = np.copy(v.astype(self._ftype))
-            self.append(Spectrum1D(spectral_axis=np.copy(wave[b].astype(self._ftype))*u.Angstrom,
-                                   flux=np.copy(flux[b].astype(self._ftype))*u.Unit('10**-17 erg/(s cm2 Angstrom)'),
-                                   uncertainty=InverseVariance(np.copy(ivar[b].astype(self._ftype))),
-                                   mask=bool_mask,
-                                   meta=band_meta))
+            self.append(Spectrum(spectral_axis=np.copy(wave[b].astype(self._ftype))*u.Angstrom,
+                                 flux=np.copy(flux[b].astype(self._ftype))*u.Unit('10**-17 erg/(s cm2 Angstrom)'),
+                                 uncertainty=InverseVariance(np.copy(ivar[b].astype(self._ftype))),
+                                 mask=bool_mask,
+                                 meta=band_meta))
 
     @property
     def bands(self):
@@ -652,11 +656,11 @@ class Spectra(SpectrumList):
                 band_meta['extra'] = dict()
                 for k, v in newextra[b].items():
                     band_meta['extra'][k] = v
-            s = Spectrum1D(spectral_axis=newwave[b]*u.Angstrom,
-                           flux=newflux[b]*u.Unit('10**-17 erg/(s cm2 Angstrom)'),
-                           uncertainty=InverseVariance(newivar),
-                           mask=bool_mask,
-                           meta=band_meta)
+            s = Spectrum(spectral_axis=newwave[b]*u.Angstrom,
+                         flux=newflux[b]*u.Unit('10**-17 erg/(s cm2 Angstrom)'),
+                         uncertainty=InverseVariance(newivar),
+                         mask=bool_mask,
+                         meta=band_meta)
             try:
                 self[i] = s
             except IndexError:
@@ -946,7 +950,7 @@ def read_spPlate(filename, limit=None):
 
     Returns
     -------
-    Spectrum1D
+    :class:`~specutils.Spectrum`
         The spectra.
     """
     with fits.open(filename) as hdulist:
@@ -968,8 +972,8 @@ def read_spPlate(filename, limit=None):
         mask = hdulist[2].data[0:limit, :] != 0
         meta['plugmap'] = Table.read(hdulist[5])[0:limit]
 
-    return Spectrum1D(flux=flux, spectral_axis=dispersion*dispersion_unit,
-                      uncertainty=uncertainty, meta=meta, mask=mask)
+    return Spectrum(flux=flux, spectral_axis=dispersion*dispersion_unit,
+                    uncertainty=uncertainty, meta=meta, mask=mask)
 
 
 def read_spZbest(filename, limit=None):
@@ -985,8 +989,8 @@ def read_spZbest(filename, limit=None):
     Returns
     -------
     tuple
-        A Table containing the redshift values and a Spectrum1D object containing
-        the best-fit models.
+        A Table containing the redshift values and a :class:`~specutils.Spectrum`
+        object containing the best-fit models.
     """
     with fits.open(filename) as hdulist:
         header = hdulist[0].header
@@ -1001,8 +1005,8 @@ def read_spZbest(filename, limit=None):
                           header['CD1_1'] * np.arange(hdulist[2].header['NAXIS1'],
                                                       dtype=hdulist[2].data.dtype))
         dispersion_unit = u.Unit('Angstrom')
-        models = Spectrum1D(flux=flux, spectral_axis=dispersion*dispersion_unit,
-                            meta=meta)
+        models = Spectrum(flux=flux, spectral_axis=dispersion*dispersion_unit,
+                          meta=meta)
     return redshifts, models
 
 

--- a/py/prospect/utilities.py
+++ b/py/prospect/utilities.py
@@ -8,7 +8,8 @@ prospect.utilities
 Utility functions for prospect.
 """
 
-import os, sys
+import os
+import sys
 import importlib.resources
 
 import numpy as np
@@ -426,8 +427,8 @@ def create_subsetdb(datadir, dirtree_type=None, spectra_type='coadd', tiles=None
        - Extensions can be fits or fits.gz
     """
 
-    if ( (nights is not None and dirtree_type not in ['pernight', 'exposures', 'cumulative'])
-        or (expids is not None and dirtree_type!='perexp' and dirtree_type!='exposures') ):
+    if ((nights is not None and dirtree_type not in ['pernight', 'exposures', 'cumulative']) or
+        (expids is not None and dirtree_type!='perexp' and dirtree_type!='exposures')):
         raise ValueError('Nights/expids option is incompatible with dirtree_type.')
     if (pixels is not None or survey_program is not None) and dirtree_type!='healpix':
         raise ValueError('Pixels/survey_program option is incompatible with dirtree_type.')

--- a/py/prospect/viewer/__init__.py
+++ b/py/prospect/viewer/__init__.py
@@ -23,9 +23,14 @@ import bokeh.plotting as bk
 
 _specutils_imported = True
 try:
-    from specutils import Spectrum1D, SpectrumList
+    from specutils import SpectrumList
 except ImportError:
     _specutils_imported = False
+else:
+    try:
+        from specutils import Spectrum
+    except ImportError:
+        from specutils import Spectrum1D as Spectrum
 
 _desispec_imported = True
 try:
@@ -146,8 +151,8 @@ def plotspectra(spectra, zcatalog=None, redrock_cat=None, notebook=False,
 
     Parameters
     ----------
-    spectra : :class:`~desispec.spectra.Spectra` or :class:`~specutils.Spectrum1D` or :class:`~specutils.SpectrumList` or list of :class:`~desispec.frame.Frame`
-        Input spectra. :class:`~specutils.Spectrum1D` are assumed to be SDSS/BOSS/eBOSS.
+    spectra : :class:`~desispec.spectra.Spectra` or :class:`~specutils.Spectrum` or :class:`~specutils.SpectrumList` or list of :class:`~desispec.frame.Frame`
+        Input spectra. :class:`~specutils.Spectrum` are assumed to be SDSS/BOSS/eBOSS.
         Otherwise DESI spectra or frames is assumed.
     zcatalog : :class:`~astropy.table.Table`, optional
         Redshift values, matched one-to-one with the input spectra.
@@ -214,7 +219,7 @@ def plotspectra(spectra, zcatalog=None, redrock_cat=None, notebook=False,
 
     #- Check input spectra.
     #- Set masked bins to NaN for compatibility with bokeh.
-    if _specutils_imported and isinstance(spectra, Spectrum1D):
+    if _specutils_imported and isinstance(spectra, Spectrum):
         # We will assume this is from an SDSS/BOSS/eBOSS spPlate file.
         survey = 'SDSS'
         nspec = spectra.flux.shape[0]

--- a/py/prospect/viewer/__init__.py
+++ b/py/prospect/viewer/__init__.py
@@ -30,6 +30,7 @@ else:
     try:
         from specutils import Spectrum
     except ImportError:
+        # support specutils 1.x
         from specutils import Spectrum1D as Spectrum
 
 _desispec_imported = True

--- a/py/prospect/viewer/__init__.py
+++ b/py/prospect/viewer/__init__.py
@@ -127,12 +127,9 @@ def create_model(spectra, zcat, archetype_fit=False, archetypes_dir=None, templa
             band_up = sorted_bands[i_band+1]
             wavecut_up = 0.5*(spectra.wave[band][-1] + spectra.wave[band_up][0])
         keep[band] = (spectra.wave[band]>wavecut_low) & (spectra.wave[band]<wavecut_up)
-    model_wave = np.concatenate(
-        [ spectra.wave[band][keep[band]] for band in sorted_bands ]
-    )
-    mflux = np.concatenate(
-        [ model_flux[band][:, keep[band]] for band in sorted_bands ],
-    axis=1)
+    model_wave = np.concatenate([spectra.wave[band][keep[band]] for band in sorted_bands])
+    mflux = np.concatenate([model_flux[band][:, keep[band]] for band in sorted_bands],
+                           axis=1)
 
     return model_wave, mflux
 
@@ -241,7 +238,7 @@ def plotspectra(spectra, zcatalog=None, redrock_cat=None, notebook=False,
         if _desispec_imported and isinstance(spectra, desispec.spectra.Spectra):
             nspec = spectra.num_spectra()
         elif _desispec_imported and isinstance(spectra, list) and isinstance(spectra[0], desispec.frame.Frame):
-        # If inputs are frames, convert to a spectra object
+            # If inputs are frames, convert to a spectra object
             spectra = frames2spectra(spectra)
             nspec = spectra.num_spectra()
             if title is None:

--- a/py/prospect/viewer/cds.py
+++ b/py/prospect/viewer/cds.py
@@ -24,6 +24,7 @@ else:
     try:
         from specutils import Spectrum
     except ImportError:
+        # support specutils 1.x
         from specutils import Spectrum1D as Spectrum
 
 _desispec_imported = True

--- a/py/prospect/viewer/cds.py
+++ b/py/prospect/viewer/cds.py
@@ -17,9 +17,14 @@ from bokeh.models import ColumnDataSource
 
 _specutils_imported = True
 try:
-    from specutils import Spectrum1D, SpectrumList
+    from specutils import SpectrumList
 except ImportError:
     _specutils_imported = False
+else:
+    try:
+        from specutils import Spectrum
+    except ImportError:
+        from specutils import Spectrum1D as Spectrum
 
 _desispec_imported = True
 try:
@@ -105,7 +110,7 @@ class ViewerCDS(object):
         if _specutils_imported and isinstance(spectra, SpectrumList):
             s = spectra
             bands = spectra.bands
-        elif _specutils_imported and isinstance(spectra, Spectrum1D):
+        elif _specutils_imported and isinstance(spectra, Spectrum):
             s = [spectra]
             bands = ['coadd']
         else : # Assume desispec Spectra obj
@@ -147,7 +152,7 @@ class ViewerCDS(object):
             s = spectra
             bands = spectra.bands
             nspec = spectra[0].flux.shape[0]
-        elif _specutils_imported and isinstance(spectra, Spectrum1D):
+        elif _specutils_imported and isinstance(spectra, Spectrum):
             s = [spectra]
             bands = ['coadd']
             nspec = spectra.flux.shape[0]

--- a/py/prospect/viewer/plots.py
+++ b/py/prospect/viewer/plots.py
@@ -12,7 +12,7 @@ Class containing bokeh plots needed for the viewer
 import numpy as np
 _specutils_imported = True
 try:
-    from specutils import Spectrum1D, SpectrumList
+    from specutils import SpectrumList
 except ImportError:
     _specutils_imported = False
 

--- a/py/prospect/viewer/vi_widgets.py
+++ b/py/prospect/viewer/vi_widgets.py
@@ -78,7 +78,10 @@ class ViewerVIWidgets(object):
 
 
     def add_vi_z(self, viewer_cds, widgets):
-    ## TODO: z_tovi behaviour if with_vi_widget=False ..?
+        """Add redshift vi information.
+
+        TODO: z_tovi behaviour if with_vi_widget=False ..?
+        """
         #- Optional VI information on redshift
         self.vi_z_input = TextInput(value='', title="VI redshift:")
         vi_z_code = self.js_files["CSVtoArray.js"] + self.js_files["save_vi.js"]

--- a/setup.cfg
+++ b/setup.cfg
@@ -106,18 +106,24 @@ exclude_lines =
 # These are normally ignored by default:
 # ignore = E121, E123, E126, E133, E226, E241, E242, E704, W503, W504
 #
-# In this package we ignore these, since there are *many* instances (>~100):
+# In this package we ignore these, since there are *many* instances, tens to hundreds:
 #
+# E127 continuation line over-indented for visual indent
 # E128 continuation line under-indented for visual indent
 # E201 whitespace after '('
 # E202 whitespace before ')'
 # E203 whitespace before ':'
+# E221 multiple spaces before operator
 # E225 missing whitespace around operator
 # E226 missing whitespace around arithmetic operator
 # E231 missing whitespace after ','
 # E251 unexpected spaces around keyword / parameter equals
 # E261 at least two spaces before inline comment
 # E265 block comment should start with '# '
+# E303 too many blank lines (2)
+# E402 module level import not at top of file
 # E501 line too long (125 > 120 characters)
-max-line-length = 120
-ignore = E128, E201, E202, E203, E225, E226, E231, E251, E261, E265, E501
+# E701 multiple statements on one line (colon)
+# W504 line break after binary operator
+# max-line-length = 120
+ignore = E127, E128, E201, E202, E203, E221, E225, E226, E231, E251, E261, E265, E303, E402, E501, E701, W504


### PR DESCRIPTION
specutils > 2.0 renames `Spectrum1D` objects to `Spectrum`. This PR adds support for that while still retaining compatibility with specutils < 2.0. In addition a few style errors are cleaned up, while clarifying the style errors that are presently ignored.

Closes #115 